### PR TITLE
Provide support for Symfony ^6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.0'
-          - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
         composer:
           - ''
           - '--prefer-lowest'

--- a/EventDispatcher/LazyEventDispatcher.php
+++ b/EventDispatcher/LazyEventDispatcher.php
@@ -80,7 +80,7 @@ class LazyEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners($eventName = null)
+    public function getListeners($eventName = null): array
     {
         return $this->getEventDispatcher()->getListeners($eventName);
     }
@@ -88,7 +88,7 @@ class LazyEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function hasListeners($eventName = null)
+    public function hasListeners($eventName = null): bool
     {
         return $this->getEventDispatcher()->hasListeners($eventName);
     }
@@ -96,7 +96,7 @@ class LazyEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getListenerPriority($eventName, $listener) 
+    public function getListenerPriority($eventName, $listener): ?int
     {
         if (!method_exists($this->getEventDispatcher(), 'getListenerPriority')) {
             throw new \BadMethodCallException('getListenerPriority() is not implemented');

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -4,7 +4,7 @@ framework:
     test:           ~
     default_locale: en
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     profiler:       { only_exceptions: false }
 
 services:

--- a/Tests/WebTestCase.php
+++ b/Tests/WebTestCase.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
@@ -29,14 +30,14 @@ abstract class WebTestCase extends BaseWebTestCase
         return static::$kernel->getContainer();
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         require_once __DIR__.'/Fixtures/app/AppKernel.php';
 
         return 'Bazinga\Bundle\PropelEventDispatcherBundle\Tests\Functional\AppKernel';
     }
 
-    protected static function createKernel(array $options = array())
+    protected static function createKernel(array $options = array()): KernelInterface
     {
         $class = self::getKernelClass();
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integrates the Propel EventDispatcherBehavior into Symfony2.",
     "license": "MIT",
     "require": {
-        "dayspring-tech/propel-eventdispatcher-behavior": "6.x-dev"
+        "dayspring-tech/propel-eventdispatcher-behavior": "^6.0"
     },
     "require-dev": {
         "php": ">=8.2",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integrates the Propel EventDispatcherBehavior into Symfony2.",
     "license": "MIT",
     "require": {
-        "dayspring-tech/propel-eventdispatcher-behavior": "^6.0"
+        "dayspring-tech/propel-eventdispatcher-behavior": "dev-feature/symfony_6 as 6.0"
     },
     "require-dev": {
         "php": ">=8.2",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integrates the Propel EventDispatcherBehavior into Symfony2.",
     "license": "MIT",
     "require": {
-        "dayspring-tech/propel-eventdispatcher-behavior": "dev-feature/symfony_6 as 6.0"
+        "dayspring-tech/propel-eventdispatcher-behavior": "^6.0"
     },
     "require-dev": {
         "php": ">=8.2",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,12 @@
     "description": "Integrates the Propel EventDispatcherBehavior into Symfony2.",
     "license": "MIT",
     "require": {
-        "dayspring-tech/propel-eventdispatcher-behavior": "5.x-dev"
+        "dayspring-tech/propel-eventdispatcher-behavior": "6.x-dev"
     },
     "require-dev": {
-        "symfony/framework-bundle": "^4.3|^5.0",
-        "symfony/yaml": "^4.0|^5.0",
+        "php": ">=8.2",
+        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/yaml": "^5.4|^6.0",
         "phpunit/phpunit": "~8.5.33|^9.0"
     },
     "authors": [


### PR DESCRIPTION
- Provide support for Symfony ^6.0
- Change required PHP version to >=8.2
- Allow for either dayspring-tech/propel1 ^1.0 or ^2.0 (implicitly via EventDispatcherBehavior)
- Depends on https://github.com/dayspring-tech/EventDispatcherBehavior/pull/1